### PR TITLE
Silence LNK4281: "undesirable base address 0x0 for x64 image"

### DIFF
--- a/EDK-II/edk2.props
+++ b/EDK-II/edk2.props
@@ -53,7 +53,7 @@
       <UACExecutionLevel />
       <UACUIAccess />
       <TypeLibraryResourceID />
-      <AdditionalOptions>/OPT:ICF=10 /IGNORE:4001 /IGNORE:4254 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/OPT:ICF=10 /IGNORE:4001 /IGNORE:4254 /IGNORE:4281 %(AdditionalOptions)</AdditionalOptions>
       <MergeSections>.rdata=.data</MergeSections>
       <SpecifySectionAttributes>.pdata,D</SpecifySectionAttributes>
       <LinkErrorReporting />

--- a/samples/samples.props
+++ b/samples/samples.props
@@ -58,7 +58,7 @@
       <UACExecutionLevel />
       <UACUIAccess />
       <TypeLibraryResourceID />
-      <AdditionalOptions>/OPT:ICF=10 /IGNORE:4001 /IGNORE:4254 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/OPT:ICF=10 /IGNORE:4001 /IGNORE:4254 /IGNORE:4281 %(AdditionalOptions)</AdditionalOptions>
       <MergeSections>.rdata=.data</MergeSections>
       <SpecifySectionAttributes>.xdata,D</SpecifySectionAttributes>
       <LinkErrorReporting />


### PR DESCRIPTION
Ref: #26 (and credits to [skochinsky](https://github.com/skochinsky) for the fix - I only made a PR out of it.)

This will silence the "undesirable base address 0x0 for x64 image" warnings (or errors, depending on your settings) when compiling images that have an explicit base address of 0 set.